### PR TITLE
Potential fix for code scanning alert no. 2: Potential use after free

### DIFF
--- a/app/src/main/cpp/session.c
+++ b/app/src/main/cpp/session.c
@@ -294,9 +294,10 @@ void *handle_events(void *a) {
         log_android(ANDROID_LOG_ERROR, "DetachCurrentThread failed");
 
     // Cleanup
+    int tun = args->tun;
     free(args);
 
-    log_android(ANDROID_LOG_WARN, "Stopped events tun=%d thread %x", args->tun, thread_id);
+    log_android(ANDROID_LOG_WARN, "Stopped events tun=%d thread %x", tun, thread_id);
     thread_id = 0;
     return NULL;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Ero-gamer/PowerTunnel-Android/security/code-scanning/2](https://github.com/Ero-gamer/PowerTunnel-Android/security/code-scanning/2)

In general, to fix use-after-free bugs, ensure that no code dereferences a pointer after it has been freed: either move all remaining uses to occur before `free`, or store any needed values in separate variables before freeing, or delay freeing until after the last use.

Here, the only post-free use of `args` is in the logging statement on line 299. The simplest, behavior-preserving fix is to record `args->tun` in a local variable before calling `free(args)`, and then use that local variable in the log statement. This avoids changing the overall lifetime of `args` or the order of other cleanup operations. Concretely, inside `handle_events` near the cleanup section, introduce a local `int tun = args->tun;` immediately before `free(args);`, then replace `args->tun` in the log statement with `tun`. No new imports or helper functions are needed; we only add one local variable and adjust the log statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
